### PR TITLE
Restructured upload file verification

### DIFF
--- a/build/dataForEditor.php
+++ b/build/dataForEditor.php
@@ -57,19 +57,15 @@ $curr_trk = $hike['trk'];
 $lat = $hike['lat'] / LOC_SCALE;
 $lng = $hike['lng'] / LOC_SCALE;
 $dirs = $hike['dirs']; 
-$usr_alert = '';
-if (isset($_SESSION['usr_alert'])) {
-    $usr_alert = $_SESSION['usr_alert'];
-    unset($_SESSION['usr_alert']);
+$user_alert = '';
+if (isset($_SESSION['user_alert']) && !empty($_SESSION['user_alert'])) {
+    $user_alert = $_SESSION['user_alert'];
+    $_SESSION['user_alert'] == '';
 }
 
 /**
  * Tab2: [photo displays (already uploaded) and any waypoints]
  */
-$svg = "M10 0l-5.2 4.9h3.3v5.1h3.8v-5.1h3.3l-5.2-4.9zm9.3 11.5l-3.2-2.1h-2l3.4 " .
-    "2.6h-3.5c-.1 0-.2.1-.2.1l-.8 2.3h-6l-.8-2.2c-.1-.1-.1-.2-.2-.2h-3.6l3.4-2." .
-    "6h-2l-3.2 2.1c-.4.3-.7 1-.6 1.5l.6 3.1c.1.5.7.9 1.2.9h16.3c.6 0 1.1-.4 " .
-    "1.3-.9l.6-3.1c.1-.5-.2-1.2-.7-1.5z";
 require "photoSelect.php";
 require "wayPointEdits.php";
 
@@ -129,7 +125,7 @@ for ($j=0; $j<$gpsDbCnt; $j++) {
     $datId[$j] = $gpsdat['datId'];
     $url[$j] = $gpsdat['url'];
     $clickText[$j] = $gpsdat['clickText'];
-    if ((strpos($url[$j], 'Map') !== false) || (strpos($url[$j], 'MAP') !== false)) {
+    if ($gpsdat['label'] !== 'GPX:') {
         $fname[$j] = substr($url[$j], 8);
     } else {
         $fname[$j] = substr($url[$j], 7);

--- a/build/editDB.js
+++ b/build/editDB.js
@@ -87,7 +87,7 @@ $('button[id^=t]').on('click', function(ev) {
     }
 });
 // place correct tab (and apply button) in foreground - on page load only
-var tab = $('#entry').text();
+var tab = $('#entry').text(); // tab # is saved in editDB.php
 var tabon = '#t' + tab;
 $(tabon).trigger('click');
 var applyAdd = '#d' + tab;
@@ -96,6 +96,18 @@ $(applyAdd).prepend(applyPos[posNo]);
 $(applyAdd).show();
 $(applyAdd).offset({top: btop, left: blft});
 var lastA = tab;
+
+// If there is a user alert to show, set the message text:
+var user_alert = '';
+if (tab == '1' && $('#ua1').text() !== '') {
+    user_alert = $('#ua1').text();
+} else if (tab == '4' && $('#ua4').text() !== '') {
+    user_alert = $('#ua4').text();
+}
+if (user_alert !== '') {
+    alert(user_alert);
+    $.get('resetAlerts.php');
+}
 
 /**
  * This section does data validation for the 'directions' URL and highlights
@@ -150,12 +162,6 @@ $('#preview').on('click', function() {
     var prevPg = '../pages/hikePageTemplate.php?age=new&hikeIndx=' + hike;
     window.open(prevPg,"_blank");
 });
-
-// If there is a user alert to show, set the message text:
-let usr_alert = $('#usr_alert').text();
-if (usr_alert !== '') {
-    alert(usr_alert);
-}
 
 // show/hide lat lng data entries
 $('#showll').on('click', function() {

--- a/build/resetAlerts.php
+++ b/build/resetAlerts.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Reset user alerts after displaying them. This prevents showing alerts
+ * repeatedly.
+ * PHP Version 7.4
+ * 
+ * @package Ktesa
+ * @author  Tom Sandberg <tjsandberg@yahoo.com>
+ * @author  Ken Cowles <krcowles29@gmail.com>
+ * @license None to date
+ */
+session_start();
+$_SESSION['user_alert'] = '';

--- a/build/tab1display.php
+++ b/build/tab1display.php
@@ -18,7 +18,7 @@
 <p id="newclus" style="display:none;"><?= $newclus;?></p>
 <p id="ctype" style="display:none"><?= $logistics;?></p>
 <p id="ptype" style="display:none">Edit</p>
-<p id="usr_alert" style="display:none"><?=$usr_alert;?></p>
+<p id="ua1" class="user_alert" style="display:none"><?=$user_alert;?></p>
 
 <div id="d1">
     <input id="ap1" type="submit" name="savePg" value="Apply" />

--- a/build/tab4display.php
+++ b/build/tab4display.php
@@ -96,6 +96,7 @@
 <?php endfor; ?>
 
 <h3>GPS Data:</h3>
+<p id="ua4" class="user_alert" style="display:none;"><?=$user_alert;?></p>
 <h3>File Upload for 'Related Hike Information' (types .gpx, .kml, .html):</h3>
 <p>Note: These files are generally useful for proposed hike track data
 and/or maps</p>


### PR DESCRIPTION
The attached diagram illustrates the basic restructured  process for validating file uploads. Please read Issues #7, #8, and #10. This has eliminated duplicate code in admin/reverseGpx.php, and streamlined the build/saveTabx.php files. The previous branch (atomicUploadFcts) is now obsolete, and that pull request will be closed. Notably, no file name checks are performed as they provide virtually no additional security. Mime types are used for file type checks - not foolproof as they can be 'spoofed', but better than simple name checks. Elevation data checks in gpx files can be turned on/off, and is on for saveTab1 gpx files (used in elevation charts) and off for saveTab4 gpx files, as no elevation data is required for mapping. As just noted, basic file checks on tab4 are now in place. All 35 test cases were successfully run prior to pushing this branch (see the related issue for the spreadsheet). 
![fileUploadProcess](https://user-images.githubusercontent.com/18312676/102020445-87c07f00-3d36-11eb-9283-519686b28871.jpg)
