### PR TITLE
Admin tools page revamped for consistency and styling

### DIFF
--- a/admin/admintools.css
+++ b/admin/admintools.css
@@ -3,12 +3,38 @@ body {
     font-size: 16px;
     margin: 0px;
 }
+button {
+    margin-bottom: 4px;
+    border-width: 1px;
+}
 legend { 
     color: darkgreen;
     font-style: italic;
+    font-size: 18px;
 }
-#sitemode {
-    font-size: 16px;
+.cats {
+    font-size: 18px;
+    color: brown;
+}
+#switchstate, #lst, #swdb {
+    margin-bottom: 12px;
+}
+#switchstate, #upld, #chgs, #site, #npix, #rel2pic, #lst, #reload,
+#drall, #ldall, #exall, #show, #swdb, #editmode, #commit, #cleanPix,
+#pinfo, #addbk, #pub, #ehdel, #revall, #revsgl {
+    color: black;
+    background-color: ghostwhite;
+}
+#switchstate:hover, #upld:hover, #chgs:hover, #site:hover, #npix:hover,
+#rel2pic:hover, #lst:hover, #reload:hover, #drall:hover, #ldall:hover,
+#exall:hover, #show:hover, #swdb:hover, #editmode:hover, #commit:hover,
+#cleanPix:hover, #pinfo:hover, #addbk:hover, #pub:hover, #ehdel:hover,
+#revall:hover, #revsgl:hover {
+    color: white;
+    background-color: saddlebrown;
+}
+#sitemode, #currstate, #emode, #cdb {
+    font-size: 18px;
 }
 #currstate {
     color: blue;
@@ -21,21 +47,21 @@ select {
     height: 24px;
     font-size: 16px;
 }
-input[type=submit] {
-    font-size: 18px;
-    color: DarkBlue;
-    cursor: pointer;
+#datepicker, #revlist {
+    height: 18px;
+    border-radius: 4px;
+    font-size: 14px;
+    padding-left: 4px;
 }
-input[type=submit]:hover {
-    background-color: BlanchedAlmond;
+#revresult, label  {
+    font-size: 18px;
 }
 input[type=file] {
     font-size: 18px;
-    color: brown;
 }
 input[type=file]:hover {
     cursor: pointer;
 }
-.ged {
-    margin-left: 24px;
+#filebrowse {
+    margin-bottom: 6px;
 }

--- a/admin/admintools.js
+++ b/admin/admintools.js
@@ -78,11 +78,11 @@ $('#swdb').on('click', function() {
     window.open('switchDb.php');
     window.close();
 });
-$('#emode').on('click', function() {
-    var butnTxt = $('#emode').text();
+$('#editmode').on('click', function() {
+    var emode = $('#emode').text();
     $.ajax({
         url: 'siteEdit.php',
-        data: {button: butnTxt},
+        data: {button: emode},
         dataType: "text",
         success: function(resp) {
             $('#emode').text(resp);
@@ -133,6 +133,16 @@ if (typeof(nopix) !== 'undefined') {
 }
 $('#addbk').on('click', function() {
     window.open("addBook.php", "_blank");
+});
+$('#revall').on('click', function(ev) {
+    ev.preventDefault();
+    $('input[name=revtype]').val("gpxall");
+    $('#revgpx').trigger('submit');
+});
+$('#revsgl').on('click', function(ev) {
+    ev.preventDefault();
+    $('input[name=revtype]').val("gpxsgl");
+    $('#revgpx').trigger('submit');
 });
 let admin_alert = $('#admin_alert').text();
 if (admin_alert !== '') {

--- a/admin/admintools.php
+++ b/admin/admintools.php
@@ -13,9 +13,9 @@
 session_start();
 require "../php/global_boot.php";
 $admin_alert = '';
-if (isset($_SESSION['usr_alert'])) {
-    $admin_alert = $_SESSION['usr_alert'];
-    unset($_SESSION['usr_alert']);
+if (isset($_SESSION['user_alert'])) {
+    $admin_alert = $_SESSION['user_alert'];
+    unset($_SESSION['user_alert']);
 }
 ?>
 <!DOCTYPE html>
@@ -53,9 +53,10 @@ if (isset($_SESSION['usr_alert'])) {
 <div style="margin-left:24px;" id="tools">
     <fieldset>
         <legend>Overall Site Management</legend>
-        <p id="sitemode">The site is currently in
-            <span id="currstate"><?= $appMode;?></span> mode:&nbsp;&nbsp;
-        <button id="switchstate">Switch Site Mode</button></p>
+        <button id="switchstate">Switch Site Mode</button>&nbsp;&nbsp;
+        <span id="sitemode">The site is currently in
+            <span id="currstate"><?= $appMode;?></span> mode:</span><br />
+        <!-- CURRENTLY NOT USED
         <form action="upldSite.php" method="POST" target="_blank"
             enctype="multipart/form-data">
             Upload:<br />
@@ -63,11 +64,14 @@ if (isset($_SESSION['usr_alert'])) {
             <input id="ufile" type="file" name="ufile" />
                 &nbsp;[Uploads Zip File and Extracts to 'upload' directory]<br />
         </form>
-        Downloads:<br />
+        -->
+        <span class="cats">Downloads:</span><br />
         <button id="chgs">Changes Only</button>
             &nbsp;[Downloads zip file]<br />
+        <!-- CURRENTLY NOT USED
         <button id="site">Entire Site</button>
             &nbsp;[Downloads compressed archive]<br />
+        -->
         <button id="npix">New Pictures</button>
             &nbsp;[Downloads new pictures since last Site upload]<br />
         <button id="rel2pic">Pictures newer than: </button>&nbsp;&nbsp;
@@ -76,9 +80,10 @@ if (isset($_SESSION['usr_alert'])) {
             <span id="dsel">OR specify calendar date&nbsp;&nbsp;
             <input style="font-size:12px;width:90px;"
                 id="datepicker" type="text" name="datepicker" /></span><br />
-        <span style="font-size:20px;color:brown;">Listings:</span><br />
-        <button id="lst">List New Files</button>&nbsp;&nbsp;[Since last upload]
-        <p>Database Management Tools:</p>
+        <span class="cats">Listings:</span><br />
+        <button id="lst">List New Files</button>
+            &nbsp;&nbsp;[Since last upload]<br />
+        <span id="mgmt" class="cats">Database Management Tools:</span><br />
         <button id="reload">Reload Database</button>&nbsp;
             [Drops All Tables and Loads All Tables]<br />
         <button id="drall">Drop All Tables</button><br />
@@ -88,14 +93,14 @@ if (isset($_SESSION['usr_alert'])) {
             [NOTE: Creates .sql file]<br />
         <button id="show">Show All Tables</button><br />
         <button id="swdb">Switch DB's</button>&nbsp;&nbsp;
-            Current database in use:
+            <span id="cdb">Current database in use:
         <?php if ($dbState === 'test') : ?>
             <span id="test" style="color:red;">Test</span>
         <?php else : ?>
             <span id="real" style="color:blue;">Site</span>
         <?php endif; ?>
-        <hr />
-        <p>Miscellaneous Tools:</p>
+            </span><br />
+        <span class="cats">Miscellaneous Tools:</span><br />
         <?php
         if ($editing === 'yes') {
             $allow = "Editing Allowed";
@@ -103,7 +108,8 @@ if (isset($_SESSION['usr_alert'])) {
             $allow = "No Editing Mode";
         }
         ?>
-        <button id="emode"><?= $allow;?></button> [Click to change modes]<br />
+        <button id="editmode" >Change Edit Mode</button>&nbsp;&nbsp;
+            <span id="emode" style="color:blue;"><?=$allow;?></span><br />
         <button id="commit">Display Commit</button>&nbsp;&nbsp;[for this site]<br />
         <button id="cleanPix">Cleanup Pictures</button>
             &nbsp;&nbsp;[removes photos not related to hikes]<br />
@@ -118,15 +124,19 @@ if (isset($_SESSION['usr_alert'])) {
     </fieldset><br />
     <fieldset>
         <legend>GPX File Edits</legend>
-        NOTE: Will download a file called "reversed.gpx"<br />
-        <form action="reverseGpx.php" method="POST" enctype="multipart/form-data" />
-            <input type="file" id="gpx2edit" name="gpx2edit" /><br />
-            <input class="ged" type="submit" name="gpxall"
-                value="Reverse All Tracks" /><br />
-            <input class="ged" type="submit" name="gpxlst"
-                value="Reverse Track No(s):" />
+        <form id="revgpx" action="reverseGpx.php" method="POST"
+            enctype="multipart/form-data" />
+            <span id="revresult">NOTE: This will download a file
+                        called "reversed.gpx"</span>
+            <div id="filebrowse">
+                <label for="gpx2edit">Upload GPX File:</label>
+                <input type="file" name="gpx2edit" />
+            </div>
+            <button id="revall">Reverse All Tracks</button><br />
+            <button id="revsgl">Reverse Only Track(s)</button>
+            <input type="hidden" name="revtype" value="" /> 
             (Single trk#, comma-list, or hyphen-range):&nbsp;
-            <input type="text" id="revlst" name="revlst" size="20" />
+            <input id="revlist" type="text" name="revlist" size="20" />
         </form>
     </fieldset><br/>
     <p id="admin_alert" style="display:none;"><?=$admin_alert;?></p>

--- a/admin/reverseGpx.php
+++ b/admin/reverseGpx.php
@@ -13,6 +13,8 @@
  */
 session_start();
 require "../php/global_boot.php";
+$revtype = filter_input(INPUT_POST, 'revtype');
+$revlist = filter_input(INPUT_POST, 'revlist');
 
 $upload = validateUpload("gpx2edit", true);
 if ($upload['file'] == '') {
@@ -21,21 +23,21 @@ if ($upload['file'] == '') {
     $_SESSION['user_alert'] = "Incorrect file type";
 }
 if (!empty($_SESSION['user_alert'])) {
-    header("Location: admintools.php");
+    header("Location: admintools.php", true);
     exit;
 }
 $dom = new DOMDocument();
 $dom->formatOutput = true;
+$dom->load($upload['loc']);
 $tracks = $dom->getElementsByTagName('trk'); // DONMNodeList object
 $trkcnt = $tracks->length;
 // process user input to determine tracks to be iteratively reversed
 $tracklist = [];
-if (isset($_POST['gpxall'])) {
+if ($revtype === 'gpxall') {
     for ($i=0; $i<$trkcnt; $i++) {
         $tracklist[$i] = $i;
     }
-} elseif (isset($_POST['gpxlst'])) {
-    $revlist = filter_input(INPUT_POST, 'revlst');
+} elseif ($revtype === 'gpxsgl') {
     $noWhiteList = preg_replace('/\s+/', '', $revlist);
     $trkels = explode(",", $noWhiteList);
     foreach ($trkels as $member) {

--- a/gpx/BlackCanyonComposite.gpx
+++ b/gpx/BlackCanyonComposite.gpx
@@ -1,20 +1,18 @@
 <?xml version="1.0"?>
 <gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wptx1="http://www.garmin.com/xmlschemas/WaypointExtension/v1" xmlns:gpxtrx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:trp="http://www.garmin.com/xmlschemas/TripExtensions/v1" xmlns:adv="http://www.garmin.com/xmlschemas/AdventuresExtensions/v1" xmlns:prs="http://www.garmin.com/xmlschemas/PressureExtension/v1" xmlns:tmd="http://www.garmin.com/xmlschemas/TripMetaDataExtensions/v1" xmlns:vptm="http://www.garmin.com/xmlschemas/ViaPointTransportationModeExtensions/v1" xmlns:ctx="http://www.garmin.com/xmlschemas/CreationTimeExtension/v1" xmlns:gpxacc="http://www.garmin.com/xmlschemas/AccelerationExtension/v1" xmlns:gpxpx="http://www.garmin.com/xmlschemas/PowerExtension/v1" xmlns:vidx1="http://www.garmin.com/xmlschemas/VideoExtension/v1" creator="Garmin Desktop App" version="1.1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/WaypointExtension/v1 http://www8.garmin.com/xmlschemas/WaypointExtensionv1.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www8.garmin.com/xmlschemas/GpxExtensionsv3.xsd http://www.garmin.com/xmlschemas/ActivityExtension/v1 http://www8.garmin.com/xmlschemas/ActivityExtensionv1.xsd http://www.garmin.com/xmlschemas/AdventuresExtensions/v1 http://www8.garmin.com/xmlschemas/AdventuresExtensionv1.xsd http://www.garmin.com/xmlschemas/PressureExtension/v1 http://www.garmin.com/xmlschemas/PressureExtensionv1.xsd http://www.garmin.com/xmlschemas/TripExtensions/v1 http://www.garmin.com/xmlschemas/TripExtensionsv1.xsd http://www.garmin.com/xmlschemas/TripMetaDataExtensions/v1 http://www.garmin.com/xmlschemas/TripMetaDataExtensionsv1.xsd http://www.garmin.com/xmlschemas/ViaPointTransportationModeExtensions/v1 http://www.garmin.com/xmlschemas/ViaPointTransportationModeExtensionsv1.xsd http://www.garmin.com/xmlschemas/CreationTimeExtension/v1 http://www.garmin.com/xmlschemas/CreationTimeExtensionsv1.xsd http://www.garmin.com/xmlschemas/AccelerationExtension/v1 http://www.garmin.com/xmlschemas/AccelerationExtensionv1.xsd http://www.garmin.com/xmlschemas/PowerExtension/v1 http://www.garmin.com/xmlschemas/PowerExtensionv1.xsd http://www.garmin.com/xmlschemas/VideoExtension/v1 http://www.garmin.com/xmlschemas/VideoExtensionv1.xsd">
-
 <metadata>
   <link href="http://www.garmin.com">
     <text>Garmin International</text>
   </link>
   <time>2017-09-14T22:38:17Z</time>
 </metadata>
-
 <trk>
     <name>Outbound</name>
     <extensions>
       <gpxx:TrackExtension>
         <gpxx:DisplayColor>red</gpxx:DisplayColor>
       </gpxx:TrackExtension>
-    </extensions>Multi
+    </extensions>
     <trkseg>
       <trkpt lat="35.728091178461909" lon="-105.839169519022107">
         <ele>2551.760000000000218</ele>


### PR DESCRIPTION
This addresses Issue #24. The buttons which toggle settings now have the same look/feel. Button styling was revamped to improve appearance, and the Reverse GPX tool now uses buttons instead of inputs, allowing for consistent styling. The latter required mods in reverseGpx.php. Two unused buttons are no longer displayed on the page, though the code remains in case of future reinstatement.