### PR TITLE
Check that 'password' and 'confirm password' match for user account updates

### DIFF
--- a/accounts/logout.php
+++ b/accounts/logout.php
@@ -15,7 +15,7 @@ require "../php/global_boot.php";
 if (isset($_GET['expire']) && $_GET['expire'] === 'Y') {
     $removeReq = "DELETE FROM `USERS` WHERE `username`=?;";
     $remove = $pdo->prepare($removeReq);
-    $remove->execute([$_SESSION['cancel']]);
+    $remove->execute([$_SESSION['username']]);
     unset($_SESSION['cancel']);
 }
 setcookie('nmh_mstr', '', 0, '/');

--- a/accounts/sessionDestroy.php
+++ b/accounts/sessionDestroy.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This script is used only for testing login activities. For example,
+ * when a USERS passwd_expire field is modified to require renewal, in
+ * order to test the process, assuming the user has a cookie set, the 
+ * session must be expired.
+ * PHP 7.4
+ * 
+ * @package Ktesa
+ * @author  Tom Sandberg <tjsandberg@yahoo.com>
+ * @author  Ken Cowles <krcowles29@gmail.com>
+ * @license No license to date* 
+ */
+session_start();
+unset($_SESSION['username']);
+unset($_SESSION['userid']);
+unset($_SESSION['expire']);
+unset($_SESSION['cookies']);
+unset($_SESSION['cookie_state']);
+echo "Done";

--- a/accounts/unifiedLogin.js
+++ b/accounts/unifiedLogin.js
@@ -199,6 +199,11 @@ switch (formtype) {
                 alert("Please accept or reject cookies");
                 return false;
             }
+            let confirm = $('#confirm').val();
+            if (confirm !== password) {
+                alert("Your passwords do not match");
+                return false;
+            }
             let formdata = {
                 submitter: 'change',
                 code: login_renew,


### PR DESCRIPTION
This adds a test in the unifiedLogin.js to resolve the issue. Also fixed a typo in logout.php, and added a simple script (sessionDestroy.php) to aid in testing account management. The script is only called during testing and is not otherwise part of the code base.