### PR TITLE
Automate the install process

### DIFF
--- a/admin/admintools.css
+++ b/admin/admintools.css
@@ -16,12 +16,23 @@ legend {
     font-size: 18px;
     color: brown;
 }
+#testsite {
+    margin-left: 24px;
+}
+.installdat {
+    height: 18px;
+    font-size: 14px;
+    width: 180px;
+}
+#sites {
+    padding-top: 6px;
+}
 #switchstate, #lst, #swdb {
     margin-bottom: 12px;
 }
 #switchstate, #upld, #chgs, #site, #npix, #rel2pic, #lst, #reload,
 #drall, #ldall, #exall, #show, #swdb, #editmode, #commit, #cleanPix,
-#pinfo, #addbk, #pub, #ehdel, #revall, #revsgl {
+#pinfo, #addbk, #pub, #ehdel, #revall, #revsgl, #install {
     color: black;
     background-color: ghostwhite;
 }
@@ -29,7 +40,7 @@ legend {
 #rel2pic:hover, #lst:hover, #reload:hover, #drall:hover, #ldall:hover,
 #exall:hover, #show:hover, #swdb:hover, #editmode:hover, #commit:hover,
 #cleanPix:hover, #pinfo:hover, #addbk:hover, #pub:hover, #ehdel:hover,
-#revall:hover, #revsgl:hover {
+#revall:hover, #revsgl:hover, #install:hover {
     color: white;
     background-color: saddlebrown;
 }

--- a/admin/admintools.js
+++ b/admin/admintools.js
@@ -5,6 +5,88 @@ $('#switchstate').on('click', function() {
     window.open('changeSiteMode.php?mode=' + current_state);
     window.close();
 });
+// uploading of test site:
+$('#upld').on('click', function() {
+    let branch = $('#ubranch').val() == '' ? 'master' : $('#ubranch').val();
+    let commit = $('#ucomm').val();
+    if (commit == '') {
+        alert("Please specify a commit number");
+        return;
+    }
+    let postdata = {branch: branch, commit: commit};
+    let ans = confirm("Proceed to upload '" + branch + "'?");
+    if (ans) {
+        $.ajax({
+            url: '../php/ftp.php',
+            method: "post",
+            data: postdata,
+            success: function(result) {
+                if (result !== "\nDone") {
+                    alert("Error: " + result)
+                } else {
+                    alert("Test site successfully uploaded via ftp");
+                }
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                var newDoc = document.open();
+                newDoc.write(jqXHR.responseText);
+                newDoc.close();
+            }
+        });
+    }
+});
+// installation script:
+$('#install').on('click', function() {
+    if (hostIs !== 'nmhikes.com' || server_loc !== 'main') {
+        alert("This tool only works on the server docroot");
+        return;
+    }
+    if (typeof auth !== 'undefined') {
+        alert("There is no authorization to run this utility");
+        return;
+    }
+    let deletions = [];
+    let deleters = $('#sites').val();
+    let copyloc = $('#copyloc').val();
+    if (copyloc == '') {
+        alert("Please specify a location from which to install files");
+        return;
+    }
+    let ajax = false;
+    if (deleters == '') {
+        let ans = confirm("No additional test site files will be deleted");
+        if (ans) {
+            ajax = true; 
+            deletions = '';  
+        } else {
+            return;
+        }
+    } else {
+        userspec = deleters.split(",");
+        for (let i=0; i<userspec.length; i++) {
+            let item = userspec[i].trim();
+            deletions.push(item);
+        }
+        ajax = true;
+    }
+    if (ajax) {
+        let postdata = {install: copyloc, delete: deletions};
+        $.ajax({
+            url: 'install.php',
+            method: "post",
+            data: postdata,
+            success: function(result) {
+                alert(result);
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                var newDoc = document.open();
+                newDoc.write(jqXHR.responseText);
+                newDoc.close();
+            }
+        });
+    }
+    return;
+});
 $('#chgs').on('click', function() {
     window.open('export_all_tables.php?dwnld=C');
 });

--- a/admin/admintools.php
+++ b/admin/admintools.php
@@ -17,6 +17,8 @@ if (isset($_SESSION['user_alert'])) {
     $admin_alert = $_SESSION['user_alert'];
     unset($_SESSION['user_alert']);
 }
+$server_loc = strlen($thisSiteRoot) > strlen($documentRoot) ?
+    'test' : 'main';
 ?>
 <!DOCTYPE html>
 <html lang="en-us">
@@ -37,7 +39,8 @@ if (isset($_SESSION['user_alert'])) {
                 dateFormat: "yy-mm-dd"
             });
         });
-        var hostIs = "<?= $_SERVER['SERVER_NAME'];?>";
+        var hostIs = "<?=$_SERVER['SERVER_NAME'];?>";
+        var server_loc = "<?=$server_loc;?>";
     </script>
 </head>
 <body>
@@ -50,21 +53,41 @@ if (isset($_SESSION['user_alert'])) {
     <?php $_SESSION['nopix'] = ''; ?>
 <?php endif; ?>
 
+<?php if ($admin) : ?>
+<script type="text/javascript">var auth;</script>
+<?php endif; ?>
+
 <div style="margin-left:24px;" id="tools">
     <fieldset>
         <legend>Overall Site Management</legend>
         <button id="switchstate">Switch Site Mode</button>&nbsp;&nbsp;
         <span id="sitemode">The site is currently in
             <span id="currstate"><?= $appMode;?></span> mode:</span><br />
-        <!-- CURRENTLY NOT USED
-        <form action="upldSite.php" method="POST" target="_blank"
-            enctype="multipart/form-data">
-            Upload:<br />
-            <button id="upld">Upload</button>&nbsp;&nbsp;
-            <input id="ufile" type="file" name="ufile" />
-                &nbsp;[Uploads Zip File and Extracts to 'upload' directory]<br />
-        </form>
-        -->
+
+        <!-- The following uploads or installs a test site -->
+        <span class="cats">Upload Test Site:</span><br />
+        <button id="upld">Upload</button>&nbsp;&nbsp;
+            [From Localhost]<br />
+        <div id="testsite">
+            <span>If not current master, specify git branch here:</span>
+            <input id="ubranch" class="installdat" type="text" 
+                placeholder="master" />&nbsp;&nbsp;
+            Commit# for upload: <input id="ucomm" class="installdat" type="text" />
+        </div>
+
+        <span class="cats">Install Test Site to Main</span><br />
+        <button id="install">Install main</button>&nbsp;&nbsp;
+            [From server]<br />
+        <div style="margin-left:24px;">
+            <span>Delete the following <strong>test site</strong>
+            directories (comma-separated list)<br />[NOTE:]
+            the <em>install</em> directory is always saved</span>
+            <br /><textarea id="sites" cols="80"></textarea>
+            <br /><span>Install from:<span>
+            <input id="copyloc" class="installdat" type="text"
+                placeholder="Test Site" /><br />
+        </div><br />
+
         <span class="cats">Downloads:</span><br />
         <button id="chgs">Changes Only</button>
             &nbsp;[Downloads zip file]<br />

--- a/admin/install.php
+++ b/admin/install.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * This script invokes the private installer.
+ * PHP Version 7.4
+ * 
+ * @package Ktesa
+ * @author  Tom Sandberg <tjsandberg@yahoo.com>
+ * @author  Ken Cowles <krcowles29@gmail.com>
+ * @license No license to date
+ */
+require "../php/global_boot.php";
+verifyAccess('ajax');
+
+require "../../ktprivate/main_install.php";

--- a/php/ftp.php
+++ b/php/ftp.php
@@ -1,0 +1,68 @@
+
+<?php
+/**
+ * Archive the incoming branch/commit. Then, create an ftp connection
+ * to nmhikes.com for uploading a new test site.
+ * PHP Version 7.4
+ * 
+ * @package Ktesa
+ * @author  Tom Sandberg <tjsandberg@yahoo.com>
+ * @author  Ken Cowles <krcowles29@gmail.com>
+ * @license No license to date
+ */
+require "../php/global_boot.php";
+
+verifyAccess('ajax');
+
+$branch   = filter_input(INPUT_POST, 'branch');
+$commit   = filter_input(INPUT_POST, 'commit');
+$testSite = $branch . "_" . $commit;
+$remote   = "{$testSite}.zip";
+$zipFile  = "../CuArchives/{$remote}";
+
+/**
+ * Create archive to upload
+ * See tools/makeArchive.sh for mods to make this work
+ */
+$cmd = $documentRoot . "/tools/makeArchive.sh {$branch} {$commit}";
+if (($result = shell_exec($cmd)) === false) {
+    echo "Archive command failed";
+    exit;
+}
+
+/**
+ * Upload to main
+ */
+chdir($documentRoot);
+if (($conn = ftp_ssl_connect('nmhikes.com')) === false) {
+    echo "Created archive, but could not connect to main";
+    exit;
+}
+// NOTE: successful login places you at docroot...
+if (!ftp_login($conn, FTP_USER, FTP_PASS)) {
+    echo "Created archive, but can't login to ftp";
+    exit;
+}
+if (!ftp_put($conn, $testSite, $zipFile, FTP_BINARY)) {
+    echo "Created archive and logged in, but failed to upload file";
+    exit;
+}
+/*
+$mkdir ="mkdir {$testSite}";
+if (ftp_exec($conn, $mkdir) === false) {
+    echo "Failed to create test site directory";
+    exit;
+}
+$chmod = "chmod 755 {$testSite}";
+if (ftp_exec($conn, $chmod) === false) {
+    echo "Could not set test site directory permissions";
+    exit;
+}
+/*
+$unzip = "unzip -qq {$remote} -d {$testSite}";
+if (!ftp_exec($conn, $unzip) === false) {
+    echo "Unzip could not be performed";
+}
+*/
+ftp_close($conn);
+echo 'Done';

--- a/tools/makeArchive.sh
+++ b/tools/makeArchive.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
-# Utility ffor making archive that can be uploaded to 000webhost 
+# Utility for making archive that can be uploaded to nmhikes.com 
 # VERSION: 1.0 Create archive, add vendor directory, add file containing commit number
-# Usage: ../tools/makeArchive branch_name commit_number
-# Must be run from git home directory. Places archive in ../CUArchives directory
-
-git archive -o ../CuArchives/$1_$2.zip $1   # Create archive
+#              Archive is placed in directory ../CuArchives
+# VERSION: 1.1 Use full path for git so that cmd will run from php; 
+#              Ensure CuArchives is available (see 'cd' command)
+# Usage: docroot/tools/makeArchive.sh branch_name commit_number
+cd /Users/kencowles/src/ktesa
+/usr/local/git/bin/git archive -o ../CuArchives/$1_$2.zip $1   # Create archive
 zip -rq ../CuArchives/$1_$2.zip vendor      # Add vendor directory
 echo $1_$2 > admin/commit_number.txt        # Commit number to text file
 zip -rq ../CuArchives/$1_$2.zip admin/commit_number.txt # Add file to archive


### PR DESCRIPTION
Some details:
Admintool has two new buttons:

1. **Upload**: this utilizes the makeArchive.sh script in tools/ to automatically create the zip file and ftp it to the main site. Although I have successfully uploaded using this button, today it gave an ftp error which may be related to the recent trouble with SSL about which we were notified. Manual extraction is still required until I can come up with a method to do this. The server does not allow the use of php's ftp_exec command (which I thought I could use to unzip). I am investigating workarounds, so this button is not functional at this time, other than to create the zip file in CuArchives. It will only operate from localhost, and required some minor mods to makeArchive.sh to accommodate php. To use it on Tom's machine will require an additional tweak.
2. **Install**: this will only work from the server's document root. The only way to test it therefore was to install it on main, which I have done, and I have verified it's correct operation. It is currently the operational code installed on main, as no 'test site' could be used to validate it. 
*Note that the functions above have some security measures in place:*

- http auth is required to get to admintools
- when using the button, the code verifies that you are actually logged in as admin (ie you cannot simply invoke site/admintools.php and expect it to work)
- the functions above are called by ajax and the scripts verify that ajax was used to invoke them
- the actual 'Install' script resides in ktprivate, so no one can even view it. It is included by the ajaxed routine.
- this restricts directory/file deletion to the actual account directories for the project and nothing else (like .well-known, .ftpquota, etc.); if project directories are added or changed, the ktprivate script will require updating.
- numerous data validation checks are included for the buttons.