### PR TITLE
Timing fixes

### DIFF
--- a/build/startNewPg.js
+++ b/build/startNewPg.js
@@ -11,6 +11,11 @@
  */
 $( function () { // when page is loaded...
 
+var error = $('#pgerror').text();
+var grpnamedup = error.indexOf('Group') !== -1 ? true : false;
+if (error !== 'clear' && error !== '') {
+    alert("Error encountered: " + error);
+}
 // load lists of 'pgTitle's & 'clusters' for data validation 
 var titleList;
 $.ajax({
@@ -62,6 +67,9 @@ $('#cluster').on('change', function() {
         $('#cls').css('display','block');
     }
 });
+if (grpnamedup) {
+    $('#cluster').trigger('click');
+}
 $('#normal').on('change', function() {
     if ($(this).prop('checked')) {
         $('#cls').css('display','none');

--- a/build/startNewPg.php
+++ b/build/startNewPg.php
@@ -10,6 +10,8 @@
  */
 session_start();
 require "../php/global_boot.php";
+$pgerror = isset($_SESSION['pgtitle']) ? $_SESSION['pgtitle'] : 'clear';
+unset($_SESSION['pgtitle']);
 
 // establish drop-downs for selecting a cluster
 $clusterSelect = getClusters($pdo);  // For hike page
@@ -37,6 +39,7 @@ $newClusterPage = str_replace('id="clusters"', 'id="cpages"', $newClusterPage);
 <p id="page_id" style="display:none">Create</p>
 
 <div id="main">
+    <p id="pgerror" style="display:none;"><?=$pgerror;?></p>
     <h2 style="color:DarkBlue;">Begin Your Journey Here!</h2>
     <h3><em>This page must be completed in order to proceed:</em></h3>
     <form action="submitNewPg.php" method="POST">

--- a/build/submitNewPg.php
+++ b/build/submitNewPg.php
@@ -28,12 +28,56 @@ $newgroup   = filter_input(INPUT_POST, 'newgroup');
 // new group takes priority
 $cname = !empty($newgroup) ? $newgroup : $cluster;
 $cname = $type === 'Cluster' ? $cname : '';
+// make sure newgroup didn't just get posted...
+if ($type === 'Cluster' && $cname == $newgroup) { 
+    $currGroups = "SELECT `group` FROM `CLUSTERS`;";
+    $newclusReq = "INSERT INTO `CLUSTERS` (`group`,`pub`,`page`) " .
+        "VALUES (?,'N','0');";
+    $pdo->beginTransaction();
+    $allgroups = $pdo->query($currGroups)->fetchAll(PDO::FETCH_COLUMN);
+    if (in_array($cname, $allgroups)) {
+        $_SESSION['pgtitle'] = "Group name '{$cname}' was recently submitted " .
+            "by another user";
+        header("Location: startNewPg.php");
+        exit;
+    }
+    $newclus = $pdo->prepare($newclusReq);
+    $newclus->execute([$cname]);
+    $pdo->commit();
+}
 
-// populate minimum data into EHIKES to record a new hike
-$query = "INSERT INTO `EHIKES` (`pgTitle`,`usrid`,`stat`,`cname`) VALUES " .
-    "(?,?,'0',?)";
-$newpg = $pdo->prepare($query);
-$newpg->execute([$pgTitle, $userid, $cname]);
+$ehTitleReq = "SELECT `pgTitle` FROM `EHIKES`;";
+$phTitleReq = "SELECT `pgTitle` FROM `HIKES`;";
+
+// Use transactions to ensure no pgTitle came in just prior to posting:
+try {
+    $pdo->beginTransaction();
+    $ehikes = $pdo->query($ehTitleReq)->fetchAll(PDO::FETCH_COLUMN);
+    $phikes = $pdo->query($phTitleReq)->fetchAll(PDO::FETCH_COLUMN);
+    $pgTitles = array_merge($ehikes, $phikes);
+    if (in_array($pgTitle, $pgTitles)) {
+        $_SESSION['pgtitle'] = "Hike name '{$pgTitle}' was recently submitted " .
+            "by another user";
+        header("Location: startNewPg.php");
+        exit;
+    } else {
+        // populate minimum data into EHIKES to record a new hike
+        $query = "INSERT INTO `EHIKES` (`pgTitle`,`usrid`,`stat`,`cname`) VALUES " .
+            "(?,?,'0',?)";
+        $newpg = $pdo->prepare($query);
+        $newpg->execute([$pgTitle, $userid, $cname]);
+    }
+} catch (Exception $e) {
+    $_SESSION['pgtitle'] = $e->getMessage();
+    header("Location: startNewPg.php");
+    exit;
+} catch (PDOException $pdoe) {
+    $_SESSION['pgtitle'] = $pdoe->getMessage();
+    header("Location: startNewPg.php");
+    exit;
+}
+$pdo->commit();
+
 // get new EHIKES indxNo
 $newhikeReq = "SELECT `indxNo` FROM `EHIKES` WHERE `pgTitle`=? AND `usrid`=?;";
 $newhike    = $pdo->prepare($newhikeReq);
@@ -41,15 +85,7 @@ $newhike->execute([$pgTitle, $userid]);
 $newhikeno  = $newhike->fetch(PDO::FETCH_ASSOC);
 $hikeNo     = $newhikeno['indxNo'];
 
-if ($type === 'Cluster' && $cname == $newgroup) { 
-    // If a new cluster group was specified for this HIKE 
-    $newclusReq = "INSERT INTO `CLUSTERS` (`group`,`pub`,`page`) " .
-        "VALUES (?,'N','0');";
-    $newclus = $pdo->prepare($newclusReq);
-    $newclus->execute([$cname]);
-}
 if ($type === 'Cluster') {
-    // Regardless, if a Cluster Hike Page:
     $clusidReq = "SELECT `clusid` FROM `CLUSTERS` WHERE `group`=?;";
     $clusid = $pdo->prepare($clusidReq);
     $clusid->execute([$cname]);

--- a/build/tab1display.php
+++ b/build/tab1display.php
@@ -67,47 +67,8 @@
 <textarea id="hike" name="pgTitle"
         maxlength="30"><?= $pgTitle;?></textarea>&nbsp;&nbsp;
     <p style="display:none;" id="locality"><?= $locale;?></p>
-    <label for="area">Locale (City/POI): </label>
-    <select id="area" name="locale">
-    <optgroup label="North/Northeast">
-        <option value="Jemez Springs">Jemez Springs</option>
-        <option value="Valles Caldera">Valles Caldera</option>
-        <option value="Los Alamos">Los Alamos</option>
-        <option value="White Rock">White Rock</option>
-        <option value="Santa Fe">Santa Fe</option>
-        <option value="Ojo Caliente">Ojo Caliente</option>
-        <option value="Abiquiu">Abiquiu</option>
-        <option value="Pecos">Pecos</option>
-        <option value="Villanueva">Villanueva</option>
-        <option value="Taos">Taos</option>
-        <option value="Pilar">Pilar</option>
-    <optgroup label="Northwest">
-        <option value="Farmington">Farmington</option>
-        <option value="San Ysidro">San Ysidro</option>
-        <option value="San Luis">San Luis</option>
-        <option value="Cuba">Cuba</option>
-        <option value="Lybrook">Lybrook</option>
-    <optgroup label="Central NM">
-        <option value="Cerrillos">Cerrillos</option>
-        <option value="Golden">Golden</option>
-        <option value="Albuquerque">Albuquerque</option>
-        <option value="Placitas">Placitas</option>
-        <option value="Corrales">Corrales</option>
-        <option value="Tijeras">Tijeras</option>
-        <option value="Tajique">Tajique</option>
-    <optgroup label="West">
-        <option value="Grants">Grants</option>
-        <option value="Ramah">Ramah</option>
-        <option value="Gallup">Gallup</option>
-    <optgroup label="South Central">
-        <option value="San Acacia">San Acacia</option>
-        <option value="San Antonio">San Antonio</option>
-        <option value="Tularosa">Tularosa</option>
-    <optgroup label="Southwest">
-        <option value="Silver City">Silver City</option>
-        <option value="Pinos Altos">Pinos Altos</option>
-        <option value="Glenwood">Glenwood</option>
-</select><br /><br />
+    <?php require "localeBox.html"; ?>
+    <br /><br />
 
 <label for="type">Hike Type: </label>
 <select id="type" name="logistics">

--- a/pages/hikePageData.php
+++ b/pages/hikePageData.php
@@ -214,7 +214,7 @@ if ($clusterPage) {
     $hike_data = []; // array to collect info for javascript
     foreach ($hikeTrackFiles as $gpx) {
         $gpxPath = '../gpx/' . $gpx;
-        $gpxData = simplexml_load_file("../gpx/" . $gpx);
+        $gpxData = simplexml_load_file($gpxPath);
         // there may be more than one track in a file (e.g. Black Canyon)
         $noOfTrks = $gpxData->trk->count();
         for ($j=0; $j<$noOfTrks; $j++) {


### PR DESCRIPTION
This branch provides 3 incremental commits to address potential race condition:
1. Hike name and cluster group (& page) naming: eliminate clashes when simultaneously naming and of the subject items by providing an atomic transaction to first check for duplicate values then: 1) if none, proceed with saving name; 2) exit with error message to user (user_alert) if name was 'just' submitted by another user. 
2. Eliminate upload file conflicts by assigning unique names to each upload based on file name, user's ip_address, and time (user can't submit simultaneous requests from same ip address). Idea from Stack Overflow
3. Eliminate assigning duplicate thumb values for photos when uploaded, as in #1. No simultaneous uploads with same name (or otherwise) will have the same thumb value (which is part of the stored filename).